### PR TITLE
Update firewall status after deletion.

### DIFF
--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -20,27 +20,38 @@ func (a *actuator) delete(ctx context.Context, infrastructure *extensionsv1alpha
 		return fmt.Errorf("could not decode provider config: %+v", err)
 	}
 
-	mclient, err := metalclient.NewClient(ctx, a.client, &infrastructure.Spec.SecretRef)
-	if err != nil {
-		return err
-	}
-
 	infrastructureStatus := &metalapi.InfrastructureStatus{}
 	if infrastructure.Status.ProviderStatus != nil {
 		if _, _, err := a.decoder.Decode(infrastructure.Status.ProviderStatus.Raw, nil, infrastructureStatus); err != nil {
 			return fmt.Errorf("could not decode infrastructure status: %+v", err)
 		}
+	}
 
-		if infrastructureStatus.Firewall.MachineID != "" {
-			machineID := decodeMachineID(infrastructureStatus.Firewall.MachineID)
-			if machineID != "" {
-				_, err = mclient.MachineDelete(machineID)
-				if err != nil {
-					a.logger.Error(err, "failed to delete firewall", "infrastructure", infrastructure.Name, "firewallID", machineID)
-					return &controllererrors.RequeueAfterError{
-						Cause:        err,
-						RequeueAfter: 30 * time.Second,
-					}
+	firewallStatus := infrastructureStatus.Firewall
+
+	mclient, err := metalclient.NewClient(ctx, a.client, &infrastructure.Spec.SecretRef)
+	if err != nil {
+		return err
+	}
+
+	if firewallStatus.MachineID != "" {
+		machineID := decodeMachineID(firewallStatus.MachineID)
+		if machineID != "" {
+			_, err = mclient.MachineDelete(machineID)
+			if err != nil {
+				a.logger.Error(err, "failed to delete firewall", "infrastructure", infrastructure.Name, "firewallID", machineID)
+				return &controllererrors.RequeueAfterError{
+					Cause:        err,
+					RequeueAfter: 30 * time.Second,
+				}
+			}
+			firewallStatus.MachineID = ""
+			err = a.updateProviderStatus(ctx, infrastructure, infrastructureConfig, firewallStatus)
+			if err != nil {
+				a.logger.Error(err, "unable to update provider status after firewall deletion", "infrastructure", infrastructure.Name)
+				return &controllererrors.RequeueAfterError{
+					Cause:        err,
+					RequeueAfter: 30 * time.Second,
 				}
 			}
 		}


### PR DESCRIPTION
As otherwise we call the "free" endpoint multiple times in case reconcilation hangs at a later point in time.