### PR TITLE
Use latest csi-lvm-controller (v0.2.2)

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -97,7 +97,7 @@ spec:
       serviceAccountName: csi-lvm-controller
       containers:
       - name: csi-lvm-controller
-        image: metalpod/csi-lvm-controller:v0.2.1
+        image: metalpod/csi-lvm-controller:v0.2.2
         imagePullPolicy: Always
         command:
         - /csi-lvm-controller
@@ -109,7 +109,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: CSI_LVM_PROVISIONER_IMAGE
-          value: "metalpod/csi-lvm-provisioner:v0.2.1"
+          value: "metalpod/csi-lvm-provisioner:v0.2.2"
         - name: CSI_LVM_DEVICE_PATTERN
           # IMPORTANT: you cannot specify a wildcard (*) at any position in the devices grok.
           value: "/dev/nvme[0-9]n[0-9]"


### PR DESCRIPTION
Use latest csi-lvm-controller (v0.2.2) to support shoots (and shooted seeds) with only one disk

See also: https://github.com/metal-pod/csi-lvm/commit/d2dbea8463e881fbf1e2caffc4652356413e2f1f