### PR TITLE
Verify that firewall is still there when reconciling infrastructure.

### DIFF
--- a/pkg/metal/types.go
+++ b/pkg/metal/types.go
@@ -73,6 +73,7 @@ const (
 	ShootAnnotationDescription = "cluster.metal-pod.io/description"
 	ShootAnnotationClusterName = "cluster.metal-pod.io/name"
 	ShootAnnotationTenant      = "cluster.metal-pod.io/tenant"
+	ShootAnnotationClusterID   = "cluster.metal-pod.io/id"
 )
 
 var (


### PR DESCRIPTION
Closes #15.

I added a validation section if the firewall still exists and belongs to this cluster in the infrastructure reconciler. 

This change would cause re-creation of cluster firewalls because I added a machine tag used for identifying if a firewall belongs to a cluster or not.